### PR TITLE
Исправления для работы на мобильных устройствах

### DIFF
--- a/layout/slider/engine.js
+++ b/layout/slider/engine.js
@@ -5,6 +5,8 @@ function lookupPathSliderKnob()
 function Slider( givenMin, givenMax, givenInitialValue, givenNotifierFunction )
 {
     var val = givenInitialValue;
+    // changed by default to make initialization work
+    var valChanged = true;
     var active = false; 
     var container = null;
     var knob = null;
@@ -16,6 +18,8 @@ function Slider( givenMin, givenMax, givenInitialValue, givenNotifierFunction )
         };
     this.setValue = function ( givenValue )
         {
+            // mark value as changed only if it really was changed
+            valChanged = givenValue != val;
             val = givenValue;
             this.resync();
         };
@@ -36,9 +40,13 @@ function Slider( givenMin, givenMax, givenInitialValue, givenNotifierFunction )
         };
     this.resync = function () 
         {   
+            // doing nothing unless changed
+            if ( ! valChanged ) return;
             var adjustedWidth = container.scrollWidth - knob.scrollWidth; 
             knob.style.left = adjustedWidth * rescaleToRange( givenMin, givenMax, val )  + "px";
-            givenNotifierFunction( val );                   
+            givenNotifierFunction( val );
+            // no need to resync again unless the value has changed
+            valChanged = false;
         };
     this.update = function ( givenEvent )
         {                   
@@ -46,7 +54,8 @@ function Slider( givenMin, givenMax, givenInitialValue, givenNotifierFunction )
             var adjustedOffset = container.offsetLeft + knob.scrollWidth / 2;
             var adjustedWidth = container.scrollWidth - knob.scrollWidth;
             var rangeRelativeX = ( givenEvent.clientX - adjustedOffset ) / adjustedWidth;
-            val = checkedInRange( givenMin, givenMax, givenMin + ( givenMax - givenMin ) * rangeRelativeX );
+            // don't access value directly, we need to track changes to it
+            this.setValue(checkedInRange( givenMin, givenMax, givenMin + ( givenMax - givenMin ) * rangeRelativeX ));
             stopEvent( givenEvent );
         };
 }

--- a/layout/slider/engine.js
+++ b/layout/slider/engine.js
@@ -49,8 +49,17 @@ function Slider( givenMin, givenMax, givenInitialValue, givenNotifierFunction )
             valChanged = false;
         };
     this.update = function ( givenEvent )
-        {                   
-            if( ! ( active && givenEvent && givenEvent.clientX ) ) return;
+        {
+            // for single-touch events fetch coordinates
+            if (givenEvent.touches && givenEvent.touches.length == 1) {
+                // clientX of a touch event is given in device pixels, where pageX is in CSS pixels
+                givenEvent.clientX = givenEvent.touches.item(0).pageX;
+            }
+
+            // event can be ignored if we're not in an active state,
+            //or if an event has no click coordinates (case of multi-touch events)
+            if ( ! active || ! ( givenEvent && givenEvent.clientX ) ) return;
+
             var adjustedOffset = container.offsetLeft + knob.scrollWidth / 2;
             var adjustedWidth = container.scrollWidth - knob.scrollWidth;
             var rangeRelativeX = ( givenEvent.clientX - adjustedOffset ) / adjustedWidth;

--- a/layout/slider/engine.js
+++ b/layout/slider/engine.js
@@ -92,8 +92,15 @@ function appendSlider( givenParent, givenSliderObject )
                 activate();   
                 resync(); 
                 update( givenEvent ); 
-            } );      
+            } );
+        addAnEvent( mySliderDiv, "touchstart", function( givenEvent ) 
+            { 
+                activate();   
+                resync(); 
+                update( givenEvent ); 
+            } );
         addAnEvent( mySliderDiv, "mouseup",  deactivate );
+        addAnEvent( mySliderDiv, "touchend",  deactivate );
         //addAnEvent( mySliderDiv, "mouseout", deactivate );     
     } 
 }


### PR DESCRIPTION
Одно исправление удаляет постоянный перерасчет результатов даже если значения слайдеров не менялись. Мобильные устройства сильно тормозят из-за этого.

Другое корректно учитывает события касаний, получая координаты в CCS пикселях.
